### PR TITLE
fix(deps): allow Angular 20

### DIFF
--- a/projects/ngx-select-ex/package.json
+++ b/projects/ngx-select-ex/package.json
@@ -3,8 +3,8 @@
   "version": "19.0.5",
   "license": "MIT",
   "peerDependencies": {
-    "@angular/common": "^18.0.0 || ^19.0.0",
-    "@angular/core": "^18.0.0 || ^19.0.0",
+    "@angular/common": ">=18.0.0",
+    "@angular/core": ">=18.0.0",
     "escape-string-regexp": "^5.0.0",
     "lodash.isequal": "^4.5.0"
   },


### PR DESCRIPTION
- Closes https://github.com/optimistex/ngx-select-ex/issues/207

I've tested ngx-select-nx with Angular 20 in [my app](https://github.com/azerothcore/Keira3) and it works without issues.

This way of requiring a minimum version (in this case`>=18.0.0`) has pros and cons. It is less strict, but it makes it unnecessary to release a new version of the library with every major Angular release; it will (usually) just work out of the box. For simple libraries this is a good trade off IMHO.